### PR TITLE
[FEATURE]: Add a repeat button in music view and a 30 second sleep before putting user to AFK

### DIFF
--- a/fun.py
+++ b/fun.py
@@ -17,6 +17,7 @@ from wavelink import Player, WaitQueue
 from utils import CustomContext
 from time import time
 from re import sub
+from asyncio import sleep
 
 import gtts
 
@@ -174,11 +175,14 @@ class Fun(commands.Cog):
     async def away_from_keyboard(self, ctx: CustomContext, message: str = ""):
         
         message = sub(r"<@!?([0-9]+)>", "", message)
+        
+        await ctx.send("{}, I set your AFK, see you later!\nGiving you 30 seconds to say goodbye to your friends before going!".format(ctx.author.mention))
+        
+        await sleep(30)
 
         self.afk_people.update(
             {ctx.author.id: [time(), message, ctx.message.id]}
         )
-        await ctx.send("{}, I set your AFK, see you later!".format(ctx.author.mention))
 
     @commands.Cog.listener("on_message")
     async def on_message(self, message: Message):

--- a/music.py
+++ b/music.py
@@ -76,6 +76,13 @@ class MusicPlayer(View):
 
         await interaction.response.send_message("Skipped: {}".format(track.title), ephemeral = True)
 
+    @button(custom_id = "REPEAT", style = ButtonSyle.blurple, emoji = "🔁")
+    async def repeat_button(self, button, interaction):
+        player = self.player
+        player.repeat = not player.repeat
+
+        await interaction.response.send_message("🔁 | Repeat " + ("enabled" if player.repeat else "disabled"), ephemeral = True)
+
     async def edit_player(self):
         embed = Embed(title = "Music Player", colour = Colour.fuchsia())
 


### PR DESCRIPTION
**Changes:**

- Added a "🔁" button (repeat button) that repeat the currently playing track.
- Added a 30 seconds sleep before adding user to afk list to say goodbye before going, sometimes we might have to say something after using the command but before going afk.